### PR TITLE
Fix generated code when option linenums is missing

### DIFF
--- a/template/tmpl/layout.tmpl
+++ b/template/tmpl/layout.tmpl
@@ -94,7 +94,7 @@
 	<script src="scripts/toc.js"></script>
 
 
-	<script>  Sunlight.highlightAll({lineNumbers:<?js= this.navOptions.linenums ?>,  showMenu: true, enableDoclinks :true}); </script>
+	<script>  Sunlight.highlightAll({lineNumbers: <?js= this.navOptions.linenums || false ?>,  showMenu: true, enableDoclinks: true}); </script>
 
 	<script>
 		$( function () {


### PR DESCRIPTION
If option `linenums` was not in config, it was generating an invalid code block and not executing code highlighting at all.
