### PR TITLE
Add https protocol to all calls to Google Web Fonts

### DIFF
--- a/template/static/styles/site.amelia.css
+++ b/template/static/styles/site.amelia.css
@@ -1,4 +1,4 @@
-@import url('//fonts.googleapis.com/css?family=Lobster|Cabin:400,700');
+@import url('https://fonts.googleapis.com/css?family=Lobster|Cabin:400,700');
 /*!
  * Bootstrap v2.3.2
  *

--- a/template/static/styles/site.cerulean.css
+++ b/template/static/styles/site.cerulean.css
@@ -1,4 +1,4 @@
-@import url(//fonts.googleapis.com/css?family=Telex);
+@import url(https://fonts.googleapis.com/css?family=Telex);
 /*!
  * Bootstrap v2.3.2
  *

--- a/template/static/styles/site.cosmo.css
+++ b/template/static/styles/site.cosmo.css
@@ -1,4 +1,4 @@
-@import url('//fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700');
+@import url('https://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700');
 /*!
  * Bootstrap v2.3.2
  *

--- a/template/static/styles/site.cyborg.css
+++ b/template/static/styles/site.cyborg.css
@@ -1,4 +1,4 @@
-@import url('//fonts.googleapis.com/css?family=Droid+Sans:400,700');
+@import url('https://fonts.googleapis.com/css?family=Droid+Sans:400,700');
 /*!
  * Bootstrap v2.3.2
  *

--- a/template/static/styles/site.darkstrap.css
+++ b/template/static/styles/site.darkstrap.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Telex);
+@import url(http:https://fonts.googleapis.com/css?family=Telex);
 /*!
  * Bootstrap v2.3.1
  *

--- a/template/static/styles/site.flatly.css
+++ b/template/static/styles/site.flatly.css
@@ -1,4 +1,4 @@
-@import url("//fonts.googleapis.com/css?family=Lato:400,700,900,400italic");
+@import url("https://fonts.googleapis.com/css?family=Lato:400,700,900,400italic");
 /*!
  * Bootstrap v2.3.2
  *

--- a/template/static/styles/site.journal.css
+++ b/template/static/styles/site.journal.css
@@ -1,4 +1,4 @@
-@import url('//fonts.googleapis.com/css?family=News+Cycle:400,700');
+@import url('https://fonts.googleapis.com/css?family=News+Cycle:400,700');
 /*!
  * Bootstrap v2.3.2
  *

--- a/template/static/styles/site.readable.css
+++ b/template/static/styles/site.readable.css
@@ -1,4 +1,4 @@
-@import url('//fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic');
+@import url('https://fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic');
 /*!
  * Bootstrap v2.3.2
  *

--- a/template/static/styles/site.simplex.css
+++ b/template/static/styles/site.simplex.css
@@ -1,4 +1,4 @@
-@import url('//fonts.googleapis.com/css?family=Josefin+Sans:300,400,700');
+@import url('https://fonts.googleapis.com/css?family=Josefin+Sans:300,400,700');
 /*!
  * Bootstrap v2.3.2
  *

--- a/template/static/styles/site.spacelab.css
+++ b/template/static/styles/site.spacelab.css
@@ -1,4 +1,4 @@
-@import url('//fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700');
+@import url('https://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700');
 /*!
  * Bootstrap v2.3.2
  *

--- a/template/static/styles/site.spruce.css
+++ b/template/static/styles/site.spruce.css
@@ -1,4 +1,4 @@
-@import url(//fonts.googleapis.com/css?family=Crete+Round);
+@import url(https://fonts.googleapis.com/css?family=Crete+Round);
 /*!
  * Bootstrap v2.3.2
  *

--- a/template/static/styles/site.superhero.css
+++ b/template/static/styles/site.superhero.css
@@ -1,4 +1,4 @@
-@import url('//fonts.googleapis.com/css?family=Oswald|Noticia+Text');
+@import url('https://fonts.googleapis.com/css?family=Oswald|Noticia+Text');
 /*!
  * Bootstrap v2.3.2
  *

--- a/template/static/styles/site.united.css
+++ b/template/static/styles/site.united.css
@@ -1,4 +1,4 @@
-@import url(//fonts.googleapis.com/css?family=Ubuntu);
+@import url(https://fonts.googleapis.com/css?family=Ubuntu);
 /*!
  * Bootstrap v2.3.2
  *


### PR DESCRIPTION
When viewing the docs offline (through the file:// protocol) the fonts cannot be downloaded, which causes the whole site to freeze. I added the https protocol to all Google Web Fonts calls in all the Bootswatch stylesheets.
