### PR TITLE
Fixed invalid protocol fred:// in site.flatly.css

### DIFF
--- a/template/static/styles/site.flatly.css
+++ b/template/static/styles/site.flatly.css
@@ -1,4 +1,4 @@
-@import url("fred://fonts.googleapis.com/css?family=Lato:400,700,900,400italic");
+@import url("//fonts.googleapis.com/css?family=Lato:400,700,900,400italic");
 /*!
  * Bootstrap v2.3.2
  *


### PR DESCRIPTION
Expected:
- Flatly style to load Lato font from fonts.googleapis.com

Actual:
- Console logs the following error:
  - GET fred://fonts.googleapis.com/css?family=Lato:400,700,900,400italic net::ERR_UNKNOWN_URL_SCHEME"
