### PR TITLE
Tables get bootstrap table class added to them

### DIFF
--- a/template/tmpl/layout.tmpl
+++ b/template/tmpl/layout.tmpl
@@ -153,6 +153,10 @@ $( function () {
 	$( '.dropdown-toggle' ).dropdown();
 	//			$( ".tutorial-section pre, .readme-section pre" ).addClass( "sunlight-highlight-javascript" ).addClass( "linenums" );
 
+  $( "table" ).each( function () {
+    var $this = $( this );
+    $this.addClass('table');
+  } );
 
 } );
 </script>


### PR DESCRIPTION
Fixes #107

Ad-hoc Markdown tables (e.g. added by a developer to a `@description`) don't otherwise have a way for the table class to be added to them, and for ad-hoc html tables, this eliminates the need to add the table class yourself