### PR TITLE
Tried to fix current bug on ext4 filesystem reported here: https://gi…

### DIFF
--- a/fixtures/documents/probe.js
+++ b/fixtures/documents/probe.js
@@ -998,16 +998,18 @@ exports.mixin = function ( obj, collection ) {
 
 /**
  * These are the supported query operators
+ * This is not actually a class, but an artifact of the documentation system
  *
  * @memberOf module:documents/probe
  * @name queryOperators
- * @class This is not actually a class, but an artifact of the documentation system
+ * @class notActuallyAClass
  */
 
 /**
  * These are the supported update operators
+ * This is not actually a class, but an artifact of the documentation system
  *
  * @memberOf module:documents/probe
  * @name updateOperators
- * @class This is not actually a class, but an artifact of the documentation system
+ * @class notActuallyAClass
  */


### PR DESCRIPTION
Fixes #109 . 
Seems that @class-tag is fully written in file name, so I reduced it. Maybe this class-tag is not necessary at all? 