### PR TITLE
Fixed issue #94

### DIFF
--- a/template/static/scripts/toc.js
+++ b/template/static/scripts/toc.js
@@ -15,6 +15,7 @@ $.fn.toc = function(options) {
     if (opts.smoothScrolling) {
       e.preventDefault();
       var elScrollTo = $(e.target).attr('href');
+      elScrollTo = elScrollTo.replace('.', '\\.');
       var $el = $(elScrollTo + ANCHOR_PREFIX);
       var offsetTop = $el.offset().top - (navbarHeight + opts.navbarOffset);
 

--- a/template/tmpl/layout.tmpl
+++ b/template/tmpl/layout.tmpl
@@ -47,7 +47,6 @@
 	<div class="col-md-12">
 	<?js } ?>
 		<div id="main">
-    		<h1 class="page-title"><?js= title ?></h1>
 			<?js= content ?>
 		</div>
 	</div>


### PR DESCRIPTION
Clicking on static method links caused an error as the if of the element
is '.functionname'
For a jQuery selection, this string needs to be ".\\functionName",
otherwise jQuery will throw a syntax error