### PR TITLE
Fix for Full Path Used for Source URL on Single Source Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,10 @@ Yes! Contribute! Test! Share your ideas! Report Bugs!
 
 ## History ##
 
+## 1.1.2 ##
+
+ * Fixes full path used as source URL for projects with one source file
+
 ## 1.1.1 ##
 
  * Bootswatch update
@@ -438,9 +442,3 @@ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
-
-
-
-
-
-

--- a/template/publish.js
+++ b/template/publish.js
@@ -542,8 +542,11 @@ exports.publish = function(taffyData, opts, tutorials) {
         shortened: null
       };
 
-      sourceFilePaths.push(sourcePath);
-
+      //Check to see if the array of source file paths already contains
+      // the source path, if not then add it
+      if (sourceFilePaths.indexOf(sourcePath) === -1) {
+          sourceFilePaths.push(sourcePath)
+      }
     }
   });
 


### PR DESCRIPTION
For projects that are from one source file (and do not set `sourceRootPath` in their `conf.json`), when displaying the source the full file path is used instead of just the file name.  

For example: 
```
Source: /Users/user/work/single-source-file.js
```
instead of the desired
```
Source: single-source-file.js
```

When building the array of `sourcePathFiles` in `publish.js`, the path is not checked to see if it already exists before adding it.  When `sourcePathFiles` is then [passed to jsdoc3's path.js](https://github.com/docstrap/docstrap/blob/master/template/publish.js#L597) to determine the `commonPrefix`, an array that contains multiple references to the same path is used and the results then fail to shorten the path to create the desired source URL.  The [single length route of path.js](https://github.com/jsdoc3/jsdoc/blob/master/lib/jsdoc/path.js#L62) provides the desired results for the `commonPrefix` so this fix simply does not add the path to the array if it is already there. 