### PR TITLE
Check if version is defined in package.json

### DIFF
--- a/template/publish.js
+++ b/template/publish.js
@@ -560,7 +560,11 @@ exports.publish = function(taffyData, opts, tutorials) {
     kind: 'package'
   }) || [])[0];
   if (packageInfo && packageInfo.name) {
-    outdir = path.join(outdir, packageInfo.name, packageInfo.version);
+    if (packageInfo.version) {
+      outdir = path.join(outdir, packageInfo.name, packageInfo.version);
+    } else {
+      outdir = path.join(outdir, packageInfo.name);
+    }
   }
   fs.mkPath(outdir);
 


### PR DESCRIPTION
If `package.json` has no `version` property, the jsdoc process fails due to `packageInfo.version` being undefined and `path.join` does not support undefined values.