### PR TITLE
Change appearance of optional parameters in signatures

### DIFF
--- a/template/publish.js
+++ b/template/publish.js
@@ -156,7 +156,8 @@ function needsSignature(doclet) {
 }
 
 function addSignatureParams(f) {
-  var params = helper.getSignatureParams(f, 'optional');
+  var optionalClass = 'optional';
+  var params = helper.getSignatureParams(f, optionalClass);
 
   f.signature = (f.signature || '') + '(';
   
@@ -164,18 +165,14 @@ function addSignatureParams(f) {
     var element = params[i];
     var seperator = (i > 0) ? ', ' : '';
 
-    if (!/class=["|']optional["|']/i.test(element)) {
+    if (!new RegExp("class=[\"|']"+optionalClass+"[\"|']").test(element)) {
       f.signature += seperator + element;
     } else {
-      f.signature += element.replace(/<span class=[\"|']optional[\"|']>(.*?)<\/span>/i, "$`["+seperator+"$1$']");
+      var regExp = new RegExp("<span class=[\"|']"+optionalClass+"[\"|']>(.*?)<\\/span>", "i");
+      f.signature += element.replace(regExp, " $`["+seperator+"$1$']");
     }
     
   }
-  
-  params.forEach(function (element) {
-    
-    
-  });
 
   f.signature += ')';
 }

--- a/template/publish.js
+++ b/template/publish.js
@@ -158,7 +158,26 @@ function needsSignature(doclet) {
 function addSignatureParams(f) {
   var params = helper.getSignatureParams(f, 'optional');
 
-  f.signature = (f.signature || '') + '(' + params.join(', ') + ')';
+  f.signature = (f.signature || '') + '(';
+  
+  for (var i = 0, l = params.length; i < l; i++) {
+    var element = params[i];
+    var seperator = (i > 0) ? ', ' : '';
+
+    if (!/class=["|']optional["|']/i.test(element)) {
+      f.signature += seperator + element;
+    } else {
+      f.signature += element.replace(/<span class=[\"|']optional[\"|']>(.*?)<\/span>/i, "$`["+seperator+"$1$']");
+    }
+    
+  }
+  
+  params.forEach(function (element) {
+    
+    
+  });
+
+  f.signature += ')';
 }
 
 function addSignatureReturns(f) {


### PR DESCRIPTION
Changed from

`publish(channel, topic, options)`

to the commonly known format:

`publish(channel, topic [, options])`