### PR TITLE
Fixed toc labels for members

### DIFF
--- a/template/tmpl/layout.tmpl
+++ b/template/tmpl/layout.tmpl
@@ -160,8 +160,9 @@ $( function () {
 	} );
 	$( "#toc" ).toc( {
 		anchorName  : function ( i, heading, prefix ) {
-			var id = $( heading ).attr( "id" );
-			return id && id.replace(/\~/g, '-inner-').replace(/\./g, '-static-') || ( prefix + i );
+			var id = heading.id;
+			return id || ( prefix + i );
+			// return id && id.replace(/\~/g, '-inner-').replace(/\./g, '-static-') || ( prefix + i );
 		},
 		selectors   : "#toc-content h1,#toc-content h2,#toc-content h3,#toc-content h4",
 		showAndHide : false,

--- a/template/tmpl/layout.tmpl
+++ b/template/tmpl/layout.tmpl
@@ -160,9 +160,7 @@ $( function () {
 	} );
 	$( "#toc" ).toc( {
 		anchorName  : function ( i, heading, prefix ) {
-			var id = heading.id;
-			return id || ( prefix + i );
-			// return id && id.replace(/\~/g, '-inner-').replace(/\./g, '-static-') || ( prefix + i );
+			return $( heading ).attr( "id" ) || ( prefix + i );
 		},
 		selectors   : "#toc-content h1,#toc-content h2,#toc-content h3,#toc-content h4",
 		showAndHide : false,

--- a/template/tmpl/members.tmpl
+++ b/template/tmpl/members.tmpl
@@ -4,7 +4,7 @@ var self = this;
 ?>
 <hr>
 <dt class="name" id="<?js= id ?>">
-    <h4><?js= data.attribs + name + (data.signature ? data.signature : '') ?></h4>
+    <h4 id="<?js= id ?>"><?js= data.attribs + name + (data.signature ? data.signature : '') ?></h4>
 
     <?js if (data.summary) { ?>
     <p class="summary"><?js= summary ?></p>


### PR DESCRIPTION
When clicking on any class member toc item, the url anchor name shows up as one of those fallback auto-generated names like `"toc2_anchor"` instead of the correct member id. It seems the problem was that the id was never added to the header element.

I also removed the logic that replaced the `~` and `.` symbols from the member anchor's with `-inner-` and `-static-` respectively. I added this some time ago in a previous pull request to solve a problem I was having, but it makes better sense now to remove it as it doesn't match up with the alternate anchor for the same link.