### PR TITLE
Created an option do disable the search

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ DocStrap ships with a `conf.json` file in the template/ directory. It is just a 
 	"outputSourcePath"      : "{boolean}",
 	"dateFormat"            : "{string}",
 	"syntaxTheme"           : "{string}",
-	"sort"					: "{boolean|string}"
+	"sort"					: "{boolean|string}",
+	"search"                : "{boolean}" 
 }
 
 ```
@@ -145,6 +146,7 @@ DocStrap ships with a `conf.json` file in the template/ directory. It is just a 
     at [sunlight themes](https://github.com/tmont/sunlight/tree/master/src/themes) which right now consists of...uh...`"default"` and `"dark"`,
     but at least you have it if you need it.
 *  __sort__ Defaults to true. Specifies whether jsdoc should sort data or use file order. Can also be a string and if so it is passed to jsdoc directly. The default string is `"longname, version, since"`.
+*  __search__ By default, the template includes a quick search box. For large APIs, the search database can be too expensive to load. If needed you can disable this feature setting this option to false. 
 
 ## Syntax Highlighting ##
 

--- a/template/tmpl/layout.tmpl
+++ b/template/tmpl/layout.tmpl
@@ -39,16 +39,18 @@
 			</li>
 			<?js }); ?>
 		</ul>
-		<div class="col-sm-3 col-md-3">
-            <form class="navbar-form" role="search">
-                <div class="input-group">
-                    <input type="text" class="form-control" placeholder="Search" name="q" id="search-input">
-                    <div class="input-group-btn">
-                        <button class="btn btn-default" id="search-submit"><i class="glyphicon glyphicon-search"></i></button>
+        <?js if (this.navOptions.search) { ?>
+            <div class="col-sm-3 col-md-3">
+                <form class="navbar-form" role="search">
+                    <div class="input-group">
+                        <input type="text" class="form-control" placeholder="Search" name="q" id="search-input">
+                        <div class="input-group-btn">
+                            <button class="btn btn-default" id="search-submit"><i class="glyphicon glyphicon-search"></i></button>
+                        </div>
                     </div>
-                </div>
-            </form>
-        </div>
+                </form>
+            </div>
+        <?js } ?>
 	</div>
 
 </div>
@@ -79,20 +81,22 @@
 </div>
 </div>
 
-<div class="modal fade" id="searchResults">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        <h4 class="modal-title">Search results</h4>
-      </div>
-      <div class="modal-body"></div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-      </div>
-    </div><!-- /.modal-content -->
-  </div><!-- /.modal-dialog -->
-</div>
+<?js if (this.navOptions.search) { ?>
+    <div class="modal fade" id="searchResults">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            <h4 class="modal-title">Search results</h4>
+          </div>
+          <div class="modal-body"></div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+          </div>
+        </div><!-- /.modal-content -->
+      </div><!-- /.modal-dialog -->
+    </div>
+<?js } ?>
 
 <footer>
 <?js if (that.navOptions.footer.length > 0){ ?>
@@ -114,7 +118,9 @@
 
 <script src="scripts/docstrap.lib.js"></script>
 <script src="scripts/toc.js"></script>
-<script type="text/javascript" src="scripts/fulltext-search-ui.js"></script>
+<?js if (this.navOptions.search) { ?>
+    <script type="text/javascript" src="scripts/fulltext-search-ui.js"></script>
+<?js } ?>
 
 <script>
 $( function () {
@@ -239,11 +245,13 @@ $( function () {
 </script>
 <?js } ?>
 
-<script type="text/javascript">
-	$(document).ready(function() {
-		SearcherDisplay.init();
-	});
-</script>
+<?js if (this.navOptions.search) { ?>
+    <script type="text/javascript">
+        $(document).ready(function() {
+            SearcherDisplay.init();
+        });
+    </script>
+<?js } ?>
 
 </body>
 </html>


### PR DESCRIPTION
The API of our system is huge and the search database requires about 9 seconds to be loaded and parsed in a fast computer. My quicksearch.html generated has about 11MB and with this size the user experience is terrible. The user navigation is blocked while Chrome and Firefox parse the JSON and mount the lunr database. 

I tried to load the quicksearch.html using a web worker but lunr.js throws a exception (Maximum call stack size exceeded). The limit of web-worker stack size is less than iframe or main script. There is a bug report about this: https://bugs.chromium.org/p/chromium/issues/detail?id=252492.

For last, I created an option to disable the search feature. It's an option valid to handle cases where the search database raises performance problems. I think that this option can be helpful to other people in the same situation.