### PR TITLE
fix: update yeti search bar button size

### DIFF
--- a/template/static/styles/site.yeti.css
+++ b/template/static/styles/site.yeti.css
@@ -6740,7 +6740,7 @@ button.close {
 }
 .navbar .btn {
   padding-top: 6px;
-  padding-bottom: 6px;
+  padding-bottom: 2px;
 }
 .navbar-form {
   margin-top: 7px;


### PR DESCRIPTION
I wanted to use yeti style within my company but the search bar size was a little off this is a quick fix for that. Sweet documentation!
![screen shot 2017-10-03 at 9 06 00 pm](https://user-images.githubusercontent.com/3335740/31156668-dbc2935e-a883-11e7-814a-84a81dcb6ef1.png)

This is how it looks after 
<img width="549" alt="screen shot 2017-10-03 at 9 45 46 pm" src="https://user-images.githubusercontent.com/3335740/31156789-3f2c4db8-a884-11e7-94b3-bc60405412bf.png">

