### PR TITLE
adds a list of symbols which fire an event to the event's documentation under the `firedBy` property.

### DIFF
--- a/template/publish.js
+++ b/template/publish.js
@@ -521,6 +521,25 @@ exports.publish = function(taffyData, opts, tutorials) {
   }
   helper.addEventListeners(data);
 
+  // Add a list of all doclets which fire an event to that event
+  // filter events
+  data({
+    kind: 'event'
+  })
+    // for each event
+    .each(function(eventDoclet) {      
+      data()
+        // find doclets firing that event and add to the list
+        .each(function(doclet) {
+          if (doclet.fires && doclet.fires.indexOf(eventDoclet.name) !== -1) {
+            // make sure a firedBy property is there
+            eventDoclet.firedBy = eventDoclet.firedBy || [];
+            // add the longname of doclet to the list
+            eventDoclet.firedBy.push(doclet.longname);
+          }
+        });
+    });
+
   var sourceFiles = {};
   var sourceFilePaths = [];
   data().each(function(doclet) {

--- a/template/tmpl/method.tmpl
+++ b/template/tmpl/method.tmpl
@@ -59,6 +59,13 @@ var self = this;
     <?js }); ?></ul>
     <?js } ?>
 
+    <?js if (data.firedBy && firedBy.length) { ?>
+    <h5>Fires This Event:</h5>
+    <ul><?js firedBy.forEach(function(f) { ?>
+        <li><?js= self.linkto(f) ?></li>
+    <?js }); ?></ul>
+    <?js } ?>
+
     <?js if (data.listeners && listeners.length) { ?>
     <h5>Listeners of This Event:</h5>
     <ul><?js listeners.forEach(function(f) { ?>


### PR DESCRIPTION
In the documentation of each event, in addition to the "Listeners of This Event:" list, a "Fires This Event:" List is added which contains all symbols which `@fires` that event.

![fires](https://user-images.githubusercontent.com/8455548/32542885-4c870258-c474-11e7-8764-b50ebcc8f284.jpg)
