### PR TITLE
Fix broken events.list.html link

### DIFF
--- a/template/publish.js
+++ b/template/publish.js
@@ -731,6 +731,13 @@ exports.publish = function(taffyData, opts, tutorials) {
     }], navigationMaster.class.link);
   }
 
+  if (view.nav.event && view.nav.event.members.length) {
+    generate('event', view.nav.event.title, [{
+      kind: 'sectionIndex',
+      contents: view.nav.event
+    }], navigationMaster.event.link);
+  }
+
   if (view.nav.namespace && view.nav.namespace.members.length) {
     generate('namespace', view.nav.namespace.title, [{
       kind: 'sectionIndex',


### PR DESCRIPTION
The drop-down navigation menu includes a link to an "events.list.html" page, which does not get created by the template:

    <a href="events.list.html" class="dropdown-toggle" data-toggle="dropdown">Events<b class="caret"></b></a>

The link is not actually clickable, but we have a tool that scans our web site for broken links, and it complains about this link.

The proposed change is simply to generate the "events.list.html" page along with the other "list" pages, e.g. "classes.list.html" etc., to avoid broken links. It does nothing to improve the contents of those "list" pages, which seems to have issues as well, e.g. see #322.