### PR TITLE
Remove menu content of the search index

### DIFF
--- a/template/publish.js
+++ b/template/publish.js
@@ -238,15 +238,11 @@ function getPathFromDoclet(doclet) {
 }
 
 function searchData(html) {
-  var startOfContent = html.indexOf("<div class=\"container\">");
+  var startOfContent = html.indexOf("<article>");
   if (startOfContent > 0) {
-    var startOfSecondContent = html.indexOf("<div class=\"container\">", startOfContent + 2);
-    if (startOfSecondContent > 0) {
-      startOfContent = startOfSecondContent;
-    }
     html = html.slice(startOfContent);
   }
-  var endOfContent = html.indexOf("<span class=\"copyright\">");
+  var endOfContent = html.indexOf("</article>");
   if (endOfContent > 0) {
     html = html.substring(0, endOfContent);
   }


### PR DESCRIPTION
The variable startOfSecondContent is always -1 because the container body is enclosed by ```<div class="container" id="toc-content">``` tag. Using ```<article>``` instead to get the relevant content. This change reduced my search index of ~49Mb to ~1.8Mb.